### PR TITLE
updating dependencies + extend air-bnb instead if air-bnb-base for react

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
-    'eslint-config-airbnb/base',
+    'eslint-config-airbnb-base',
     require.resolve('./rules/default')
   ],
   rules: {}

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   "dependencies": {
     "babel-eslint": "^6.0.4",
     "eslint-config-airbnb": "^8.0.0",
-    "eslint-plugin-import": "^1.6.0",
-    "eslint-plugin-jsx-a11y": "^1.0.3",
+    "eslint-plugin-import": "^1.6.1",
+    "eslint-plugin-jsx-a11y": "^1.0.4",
     "eslint-plugin-react": "^5.0.1",
     "estraverse-fb": "^1.3.1"
   },
   "devDependencies": {
-    "eslint": "^2.8.0"
+    "eslint": "^2.9.0"
   }
 }

--- a/react.js
+++ b/react.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
-    'eslint-config-airbnb/base',
+    'eslint-config-airbnb',
     require.resolve('./rules/default'),
     require.resolve('./rules/react')
   ],


### PR DESCRIPTION
- update dependencies
- extend air-bnb-base by default and air-bnb for react
